### PR TITLE
String2 and tags by name

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -415,7 +415,6 @@ func (t *EIPTCP) allTags(tagMap map[string]*Tag, instanceID types.UDInt) (map[st
 
 	mrres := new(packet.MessageRouterResponse)
 	mrres.Decode(res.Packet.Items[1].Data)
-	//fmt.Println(res.Packet.Items[1].Data)
 
 	io1 := bufferx.New(mrres.ResponseData)
 	for io1.Len() > 0 {

--- a/tag.go
+++ b/tag.go
@@ -3,12 +3,15 @@ package go_ethernet_ip
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"github.com/loki-os/go-ethernet-ip/bufferx"
 	"github.com/loki-os/go-ethernet-ip/messages/packet"
 	"github.com/loki-os/go-ethernet-ip/path"
 	"github.com/loki-os/go-ethernet-ip/types"
 	"math"
+	"strings"
 	"sync"
 	"unicode"
 )

--- a/tag.go
+++ b/tag.go
@@ -102,24 +102,10 @@ func (t *Tag) readParser(mr *packet.MessageRouterResponse, cb func(func())) {
 	if _t == 0x2a0 {
 		io.RL(&_t)
 	}
+
 	payload := make([]byte, io.Len())
 	io.RL(payload)
-	fmt.Println(payload)
-	if yes, bit := t.GetIntegerBit(); yes  {
-		sliceBitNum := int(math.Mod(float64(bit), 8))
-		byteNum := byte(math.Pow(2, float64(sliceBitNum)))
-		indexBitNum := int(math.Trunc(float64(bit) / 8))
-		fmt.Println(sliceBitNum)
-		fmt.Println(byteNum)
-		fmt.Println(indexBitNum)
-		for i, v := range payload { //this count be not a loop. you can refernece payload[indexBitNum] directly and make the assessment on the individual bit
-			if indexBitNum == i {
-				payload[i] = v & byteNum
-			} else {
-				payload[i] = 0x00
-			}
-		}
-	}
+
 	if bytes.Compare(t.value, payload) != 0 {
 		t.value = payload
 		if t.Onchange != nil {

--- a/tag.go
+++ b/tag.go
@@ -624,8 +624,7 @@ func (tag *Tag) readByName() *packet.MessageRouterRequest {
 	return mr
 }
 
-func (t *EIPTCP) NewTag(name string, instID types.UDInt) *Tag {
-	tag := new(Tag)
+func (t *EIPTCP) NewTag(name string, instID types.UDInt, tag *Tag)  {
 	tag.Lock = new(sync.Mutex)
 	tag.TCP = t
 	nameBytes := []byte(name)
@@ -634,5 +633,5 @@ func (t *EIPTCP) NewTag(name string, instID types.UDInt) *Tag {
 		tag.name = nameBytes
 	}
 	tag.instanceID = instID
-	return tag
+	return
 }


### PR DESCRIPTION
1. During testing of string tag using an L8 Allen Bradley PLC, type returned 0x8fce. Added this number to the existing type handler.
2. Added tag constructor and ReadTagByName to support UDT member reading as well as normal data type tag reading without the need to call AllTags

Comment with any questions/concerns (can update in order to address issues); appreciate the consideration.
